### PR TITLE
Update KMEHR version

### DIFF
--- a/.github/workflows/XML_validations.yml
+++ b/.github/workflows/XML_validations.yml
@@ -34,7 +34,7 @@ jobs:
       - name: ☕ Install dependencies
         run: sudo apt-get update && sudo apt-get install -y libxml2-utils
       - name: 🤖 Validate MS XML files
-        run: xmllint --catalogs --noout --schema ./xsd-kmehr/ehealth-kmehr/XSD/kmehr_elements-1_37.xsd ./output/ms/*.xml
+        run: xmllint --catalogs --noout --schema ./xsd-kmehr/ehealth-kmehr/XSD/kmehr_elements-1_40.xsd ./output/ms/*.xml
 
   wellformedXMLS_PCDHbasic:
     runs-on: ubuntu-latest

--- a/TEMPLATES/PARTIAL_MS.xml
+++ b/TEMPLATES/PARTIAL_MS.xml
@@ -2,7 +2,7 @@
 <kmehrmessage xmlns="http://www.ehealth.fgov.be/standards/kmehr/schema/v1" xmlns:ns2="http://www.w3.org/2001/04/xmlenc#" xmlns:ns3="http://www.w3.org/2000/09/xmldsig#">
     <header>
         <standard>
-            <cd S="CD-STANDARD" SV="1.4">20161201</cd>
+            <cd S="CD-STANDARD" SV="1.4">20231110</cd>
         </standard>
         <id S="ID-KMEHR" SV="1.0">1990001916.2018041091404668030</id>
         <date>2018-04-19</date>

--- a/TEMPLATES/PARTIAL_MS_WITH_NS.xml
+++ b/TEMPLATES/PARTIAL_MS_WITH_NS.xml
@@ -2,7 +2,7 @@
 <ns2:kmehrmessage xmlns="http://www.ehealth.fgov.be/hubservices/core/v3" xmlns:ns2="http://www.ehealth.fgov.be/standards/kmehr/schema/v1" xmlns:ns3="http://www.ehealth.fgov.be/hubservices/protocol/v3" xmlns:ns4="urn:be:fgov:ehealth:metahub:core:v2">
     <ns2:header>
         <ns2:standard>
-            <ns2:cd S="CD-STANDARD" SV="1.4">20161201</ns2:cd>
+            <ns2:cd S="CD-STANDARD" SV="1.4">20231110</ns2:cd>
         </ns2:standard>
         <ns2:id S="ID-KMEHR" SV="1.0">1990001916.2018041091404668030</ns2:id>
         <ns2:date>2018-04-19</ns2:date>

--- a/catalog.xml
+++ b/catalog.xml
@@ -1,6 +1,6 @@
 <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
     <uri
         name="http://www.ehealth.fgov.be/standards/kmehr/schema/v1"
-        uri="./xsd-kmehr/ehealth-kmehr/XSD/kmehr_elements-1_37.xsd"
+        uri="./xsd-kmehr/ehealth-kmehr/XSD/kmehr_elements-1_40.xsd"
     />
 </catalog>

--- a/documentation/docs/faq/02.mdx
+++ b/documentation/docs/faq/02.mdx
@@ -18,7 +18,7 @@ import TabItem from '@theme/TabItem';
 ## Prerequisites
 
 - [Vitalink Schematron](https://github.com/smals-jy/KMEHR-tests/blob/main/medicationscheme-validation-v2.xslt)
-- [Local XSDs of the KMEHR version you would like to use](https://www.ehealth.fgov.be/standards/kmehr/en/page/xschema) (e.g `1.37.0`)
+- [Local XSDs of the KMEHR version you would like to use](https://www.ehealth.fgov.be/standards/kmehr/en/page/xschema) (e.g `1.40.2`)
 - [xslt3](https://www.npmjs.com/package/xslt3), a Node.JS command-line tool you can install
 - XMLLint, which is an [Open Source](https://gitlab.gnome.org/GNOME/libxml2) tool you can download on your platform :
 
@@ -55,7 +55,7 @@ import TabItem from '@theme/TabItem';
 2. Check if XML file is valid KMEHR file, by running a command similar to this one :
 
 ```bash
-xmllint --catalogs --noout --schema ./xsd-kmehr/ehealth-kmehr/XSD/kmehr_elements-1_37.xsd ./path/to/your/file/test-MS.xml
+xmllint --catalogs --noout --schema ./xsd-kmehr/ehealth-kmehr/XSD/kmehr_elements-1_40.xsd ./path/to/your/file/test-MS.xml
 ```
 
 3. If it is valid, you will receive a status 0 of this command. Otherwise, you have an error somewhere ...

--- a/documentation/docs/faq/08.mdx
+++ b/documentation/docs/faq/08.mdx
@@ -1,6 +1,6 @@
 ---
-description: How to test the new KMEHR version impacts on Medication Scheme ?
-title: ⚠️ KMEHR 1.40.2 testing (Draft)
+description: How to test the 1.40.2 KMEHR version impacts on Medication Scheme ?
+title: ⚠️ KMEHR 1.40.2 testing
 ---
 
 ## Why ?

--- a/medicationscheme-validation-v2.xslt
+++ b/medicationscheme-validation-v2.xslt
@@ -254,10 +254,10 @@
 
       <!--ASSERT ERROR-->
       <xsl:choose>
-         <xsl:when test="kmehr:standard/kmehr:cd = '20161201'"/>
+         <xsl:when test="kmehr:standard/kmehr:cd = '20231110'"/>
          <xsl:otherwise>
             <svrl:failed-assert xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
-                                test="kmehr:standard/kmehr:cd = '20161201'">
+                                test="kmehr:standard/kmehr:cd = '20231110'">
                <xsl:attribute name="id">version</xsl:attribute>
                <xsl:attribute name="flag">structure</xsl:attribute>
                <xsl:attribute name="role">ERROR</xsl:attribute>
@@ -265,7 +265,7 @@
                   <xsl:apply-templates select="." mode="schematron-select-full-path"/>
                </xsl:attribute>
                <svrl:text>
-                  The cd in &lt;standard&gt; must be equal to "20161201". (Current: <xsl:text/>
+                  The cd in &lt;standard&gt; must be equal to "20231110". (Current: <xsl:text/>
                   <xsl:value-of select="kmehr:standard/kmehr:cd"/>
                   <xsl:text/>)
                </svrl:text>


### PR DESCRIPTION
KMEHR 1.40.2 is finally in production so it is time to update the code base as well : 
- https://status.ehealth.fgov.be/fr/intervention/O00JtJUBQWgbe9OHYu7P
- https://status.ehealth.fgov.be/fr/intervention/PE0NtJUBQWgbe9OHfe5Y 
- https://status.ehealth.fgov.be/fr/intervention/EvChlJUB8byy-JGDzQYS