### PR TITLE
docs: Update XML links

### DIFF
--- a/documentation/docs/tests/ms/demo/IMEC_01.mdx
+++ b/documentation/docs/tests/ms/demo/IMEC_01.mdx
@@ -137,5 +137,5 @@ See if software in test can handle common real-life situations provided by IMEC 
 
 ## Files
 
-- [XML file](https://github.com/smals-jy/KMEHR-tests/blob/main/output/ms/IMEC_01.xml)
+- [XML file](/output/ms/IMEC_01.xml)
 - [Configuration file](https://github.com/smals-jy/KMEHR-tests/blob/main/configurations/ms/IMEC_01.ts)

--- a/documentation/docs/tests/ms/demo/RIZIV_01.mdx
+++ b/documentation/docs/tests/ms/demo/RIZIV_01.mdx
@@ -28,5 +28,5 @@ See if software in test can handle common real-life situations provided by RIZIV
 
 ## Files
 
-- [XML file](https://github.com/smals-jy/KMEHR-tests/blob/main/output/ms/RIZIV_01.xml)
+- [XML file](/output/ms/RIZIV_01.xml)
 - [Configuration file](https://github.com/smals-jy/KMEHR-tests/blob/main/configurations/ms/RIZIV_01.ts)

--- a/documentation/docs/tests/ms/demo/Vitalink_Acceptatie_Testdata.mdx
+++ b/documentation/docs/tests/ms/demo/Vitalink_Acceptatie_Testdata.mdx
@@ -26,5 +26,5 @@ See if software in test can handle a reproduction of Vitalink Test data as descr
 
 ## Files
 
-- [XML file](https://github.com/smals-jy/KMEHR-tests/blob/main/output/ms/Vitalink_Acceptatie_Testdata.xml)
+- [XML file](/output/ms/Vitalink_Acceptatie_Testdata.xml)
 - [Configuration file](https://github.com/smals-jy/KMEHR-tests/blob/main/configurations/ms/Vitalink_Acceptatie_Testdata.ts)

--- a/documentation/docs/tests/ms/read/ts-01.mdx
+++ b/documentation/docs/tests/ms/read/ts-01.mdx
@@ -34,7 +34,7 @@ See if software in test can handle the formats of medication possible in KMEHR :
 
 ## Files
 
-- [XML file](https://github.com/smals-jy/KMEHR-tests/blob/main/output/ms/TS-01-identifiers.xml)
+- [XML file](/output/ms/TS-01-identifiers.xml)
 - [Configuration file](https://github.com/smals-jy/KMEHR-tests/blob/main/configurations/ms/TS-01-identifiers.json)
 
 ## Expected results 

--- a/documentation/docs/tests/ms/read/ts-02.mdx
+++ b/documentation/docs/tests/ms/read/ts-02.mdx
@@ -48,7 +48,7 @@ See if software in test can handle the formats of posologies possible in KMEHR, 
 
 ## Files
 
-- [XML file](https://github.com/smals-jy/KMEHR-tests/blob/main/output/ms/TS-02-posologies.xml)
+- [XML file](/output/ms/TS-02-posologies.xml)
 - [Configuration file](https://github.com/smals-jy/KMEHR-tests/blob/main/configurations/ms/TS-02-posologies.json)
 
 ## Expected results 

--- a/documentation/docs/tests/ms/read/ts-03.mdx
+++ b/documentation/docs/tests/ms/read/ts-03.mdx
@@ -51,7 +51,7 @@ In other words, all values of [CD-ADMINISTRATIONUNIT](https://www.ehealth.fgov.b
 
 ## Files
 
-- [XML file](https://github.com/smals-jy/KMEHR-tests/blob/main/output/ms/TS-03-CD-ADMINISTRATIONUNIT.xml)
+- [XML file](/output/ms/TS-03-CD-ADMINISTRATIONUNIT.xml)
 - [Configuration file](https://github.com/smals-jy/KMEHR-tests/blob/main/configurations/ms/TS-03-CD-ADMINISTRATIONUNIT.ts)
 
 ## Expected results 

--- a/documentation/docs/tests/ms/read/ts-04.mdx
+++ b/documentation/docs/tests/ms/read/ts-04.mdx
@@ -41,7 +41,7 @@ In other words, all values of [CD-DAYPERIOD](https://www.ehealth.fgov.be/standar
 
 ## Files
 
-- [XML file](https://github.com/smals-jy/KMEHR-tests/blob/main/output/ms/TS-04-CD-DAYPERIOD.xml)
+- [XML file](/output/ms/TS-04-CD-DAYPERIOD.xml)
 - [Configuration file](https://github.com/smals-jy/KMEHR-tests/blob/main/configurations/ms/TS-04-CD-DAYPERIOD.ts)
 
 ## Expected results 

--- a/documentation/docs/tests/ms/read/ts-05.mdx
+++ b/documentation/docs/tests/ms/read/ts-05.mdx
@@ -80,7 +80,7 @@ In other words, only a subset of [CD-DRUG-ROUTE](https://www.ehealth.fgov.be/sta
 
 ## Files
 
-- [XML file](https://github.com/smals-jy/KMEHR-tests/blob/main/output/ms/TS-05-CD-DRUG-ROUTE.xml)
+- [XML file](/output/ms/TS-05-CD-DRUG-ROUTE.xml)
 - [Configuration file](https://github.com/smals-jy/KMEHR-tests/blob/main/configurations/ms/TS-05-CD-DRUG-ROUTE.ts)
 
 ## Expected results 

--- a/documentation/docs/tests/ms/read/ts-06.mdx
+++ b/documentation/docs/tests/ms/read/ts-06.mdx
@@ -41,7 +41,7 @@ In other words, all values of [CD-PERIODICITY](https://www.ehealth.fgov.be/stand
 
 ## Files
 
-- [XML file](https://github.com/smals-jy/KMEHR-tests/blob/main/output/ms/TS-06-CD-PERIODICITY.xml)
+- [XML file](/output/ms/TS-06-CD-PERIODICITY.xml)
 - [Configuration file](https://github.com/smals-jy/KMEHR-tests/blob/main/configurations/ms/TS-06-CD-PERIODICITY.ts)
 
 ## Expected results 

--- a/documentation/docs/tests/ms/read/ts-07.mdx
+++ b/documentation/docs/tests/ms/read/ts-07.mdx
@@ -69,7 +69,7 @@ See if software in test can handle `begincondition` / `endcondition` / `endmomen
 
 ## Files
 
-- [XML file](https://github.com/smals-jy/KMEHR-tests/blob/main/output/ms/TS-07-BEGIN_END_CONDITIONS.xml)
+- [XML file](/output/ms/TS-07-BEGIN_END_CONDITIONS.xml)
 - [Configuration file](https://github.com/smals-jy/KMEHR-tests/blob/main/configurations/ms/TS-07-BEGIN_END_CONDITIONS.ts)
 
 ## Expected results 

--- a/documentation/docs/tests/ms/read/ts-08.mdx
+++ b/documentation/docs/tests/ms/read/ts-08.mdx
@@ -82,7 +82,7 @@ Medications with/without end date under following scenarios :
 
 ## Files
 
-- [XML file](https://github.com/smals-jy/KMEHR-tests/blob/main/output/ms/TS-08-THERAPEUTIC_SUSPENSIONS.xml)
+- [XML file](/output/ms/TS-08-THERAPEUTIC_SUSPENSIONS.xml)
 - [Configuration file](https://github.com/smals-jy/KMEHR-tests/blob/main/configurations/ms/TS-08-THERAPEUTIC_SUSPENSIONS.ts)
 
 ## Expected results

--- a/documentation/docs/tests/ms/read/ts-09.mdx
+++ b/documentation/docs/tests/ms/read/ts-09.mdx
@@ -98,7 +98,7 @@ See if software in test can handle very specific cases authorized by [MS Cookboo
 
 ## Files
 
-- [XML file](https://github.com/smals-jy/KMEHR-tests/blob/main/output/ms/TS-09-corner_cases.xml)
+- [XML file](/output/ms/TS-09-corner_cases.xml)
 - [Configuration file](https://github.com/smals-jy/KMEHR-tests/blob/main/configurations/ms/TS-09-corner_cases.ts)
 
 ## Expected results

--- a/documentation/docs/tests/ms/read/ts-10.mdx
+++ b/documentation/docs/tests/ms/read/ts-10.mdx
@@ -37,7 +37,7 @@ See if software in test can handle medications that are in future (e.g 2099) acc
 
 ## Files
 
-- [XML file](https://github.com/smals-jy/KMEHR-tests/blob/main/output/ms/TS-10-future-drugs.xml)
+- [XML file](/output/ms/TS-10-future-drugs.xml)
 - [Configuration file](https://github.com/smals-jy/KMEHR-tests/blob/main/configurations/ms/TS-10-future-drugs.ts)
 
 ## Expected results

--- a/documentation/docs/tests/ms/read/ts-11.mdx
+++ b/documentation/docs/tests/ms/read/ts-11.mdx
@@ -103,7 +103,7 @@ Inspired by IMEC own set of test : https://wiki.ivlab.ilabt.imec.be/display/VLMS
 
 ## Files
 
-- [XML file](https://github.com/smals-jy/KMEHR-tests/blob/main/output/ms/TS-11-Unexpected_Scenarios.xml)
+- [XML file](/output/ms/TS-11-Unexpected_Scenarios.xml)
 - [Configuration file](https://github.com/smals-jy/KMEHR-tests/blob/main/configurations/ms/TS-11-Unexpected_Scenarios.ts)
 
 ## Expected results

--- a/documentation/docs/tests/ms/read/ts-12.mdx
+++ b/documentation/docs/tests/ms/read/ts-12.mdx
@@ -62,7 +62,7 @@ See if software in test can properly handle author [HCparty](https://www.ehealth
 
 ## Files
 
-- [XML file](https://github.com/smals-jy/KMEHR-tests/blob/main/output/ms/TS-12-Software-Info.xml)
+- [XML file](/output/ms/TS-12-Software-Info.xml)
 - [Configuration file](https://github.com/smals-jy/KMEHR-tests/blob/main/configurations/ms/TS-12-Software-Info.ts)
 
 ## Expected results

--- a/documentation/docs/tests/ms/read/ts-13.mdx
+++ b/documentation/docs/tests/ms/read/ts-13.mdx
@@ -40,7 +40,7 @@ See if software in test can handle the formats of duration possible in KMEHR, au
 
 ## Files
 
-- [XML file](https://github.com/smals-jy/KMEHR-tests/blob/main/output/ms/TS-13-duration.xml)
+- [XML file](/output/ms/TS-13-duration.xml)
 - [Configuration file](https://github.com/smals-jy/KMEHR-tests/blob/main/configurations/ms/TS-13-duration.ts)
 
 ## Expected results


### PR DESCRIPTION
Will be better for faster downloads

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated all XML file links in the test documentation from absolute GitHub URLs to relative paths within the site for easier access.
  * Added missing newlines at the end of several documentation files for improved formatting consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->